### PR TITLE
Enable scrolling on the demo

### DIFF
--- a/build/demo.css
+++ b/build/demo.css
@@ -62,7 +62,6 @@ body {
   height: 100%;
   font-family: 'Lato', 'Helvetica Neue', 'Helvetica', sans-serif;
   display: table;
-  overflow: hidden;
 }
 /* main style start */
 #page {


### PR DESCRIPTION
When the viewport is smaller, the content on the demo page overflows. This PR re-enables scrolling.

<img width="820" alt="Screen Shot 2020-06-09 at 10 00 23 PM" src="https://user-images.githubusercontent.com/40002855/84228736-ababbb00-aa9c-11ea-8df3-2e8a271f4c2b.png">
